### PR TITLE
ci: Run workflows only on code changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,17 @@ on:
     branches: [ main, develop ]
   pull_request:
     branches: [ main, develop ]
+    paths:
+      - 'src/**'
+      - 'bin/**'
+      - 'tests/**'
+      - 'composer.json'
+      - 'composer.lock'
+      - 'phpunit.xml.dist'
+      - 'Dockerfile*'
+      - 'docker-compose*.yml'
+      - '.github/workflows/**'
+      - 'templates/**'
 
 jobs:
   tests:

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -3,8 +3,28 @@ name: Docker Tests
 on:
   push:
     branches: [ main, develop ]
+    paths:
+      - 'src/**'
+      - 'bin/**'
+      - 'tests/**'
+      - 'composer.json'
+      - 'composer.lock'
+      - 'phpunit.xml.dist'
+      - 'Dockerfile*'
+      - 'docker-compose*.yml'
+      - '.github/workflows/**'
   pull_request:
     branches: [ main, develop ]
+    paths:
+      - 'src/**'
+      - 'bin/**'
+      - 'tests/**'
+      - 'composer.json'
+      - 'composer.lock'
+      - 'phpunit.xml.dist'
+      - 'Dockerfile*'
+      - 'docker-compose*.yml'
+      - '.github/workflows/**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -3,8 +3,30 @@ name: Self-Test (Test the Tester)
 on:
   push:
     branches: [ main, develop ]
+    paths:
+      - 'src/**'
+      - 'bin/**'
+      - 'tests/**'
+      - 'composer.json'
+      - 'composer.lock'
+      - 'phpunit.xml.dist'
+      - 'Dockerfile*'
+      - 'docker-compose*.yml'
+      - '.github/workflows/**'
+      - 'templates/**'
   pull_request:
     branches: [ main, develop ]
+    paths:
+      - 'src/**'
+      - 'bin/**'
+      - 'tests/**'
+      - 'composer.json'
+      - 'composer.lock'
+      - 'phpunit.xml.dist'
+      - 'Dockerfile*'
+      - 'docker-compose*.yml'
+      - '.github/workflows/**'
+      - 'templates/**'
   schedule:
     - cron: '0 2 1 * *'  # Monthly on the 1st day of the month
 


### PR DESCRIPTION
- Add paths filter to CI workflow to skip documentation changes
- Add paths filter to Docker Tests workflow
- Add paths filter to Self-Test workflow
- CI will now run only when source code, tests, or configuration files are modified
- Documentation changes (docs/, README.md, etc.) will not trigger CI