### PR TITLE
fix: ensure test reports are always saved as artifacts

### DIFF
--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -145,7 +145,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test-results-${{ matrix.framework-config.framework }}-${{ matrix.framework-config.version }}-php-${{ matrix.php-version }}
+          name: test-results-${{ matrix.framework-config.framework }}-${{ replace(matrix.framework-config.version, '*', 'x') }}-php-${{ matrix.php-version }}
           path: /tmp/reports/
           retention-days: 30
           if-no-files-found: warn

--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -141,11 +141,20 @@ jobs:
           mkdir -p /tmp/reports
           echo "{\"test_exit_code\": ${{ steps.test.outcome == 'success' && '0' || '1' }}, \"timestamp\": \"$(date -Iseconds)\"}" > /tmp/reports/test-status.json
       
+      - name: Prepare artifact name
+        if: always()
+        id: artifact-name
+        run: |
+          VERSION="${{ matrix.framework-config.version }}"
+          VERSION_CLEAN=$(echo "$VERSION" | tr '*' 'x')
+          ARTIFACT_NAME="test-results-${{ matrix.framework-config.framework }}-${VERSION_CLEAN}-php-${{ matrix.php-version }}"
+          echo "name=${ARTIFACT_NAME}" >> $GITHUB_OUTPUT
+      
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test-results-${{ matrix.framework-config.framework }}-${{ replace(matrix.framework-config.version, '*', 'x') }}-php-${{ matrix.php-version }}
+          name: ${{ steps.artifact-name.outputs.name }}
           path: /tmp/reports/
           retention-days: 30
           if-no-files-found: warn

--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -115,6 +115,7 @@ jobs:
           EOF
       
       - name: Run compatibility test
+        id: test
         run: |
           php bin/compatibility-tester test \
             --config=/tmp/test-config.yml \
@@ -127,17 +128,25 @@ jobs:
       - name: Generate report
         if: always()
         run: |
+          mkdir -p /tmp/reports
           php bin/compatibility-tester report \
             --config=/tmp/test-config.yml \
             --package-path=/tmp/test-package \
             --format=json \
-            --output=/tmp/report.json || true
+            --output=/tmp/reports/report.json || echo '{"error": "Failed to generate report", "timestamp": "'$(date -Iseconds)'"}' > /tmp/reports/report.json
+      
+      - name: Save test output
+        if: always()
+        run: |
+          mkdir -p /tmp/reports
+          echo "{\"test_exit_code\": ${{ steps.test.outcome == 'success' && '0' || '1' }}, \"timestamp\": \"$(date -Iseconds)\"}" > /tmp/reports/test-status.json
       
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: test-results-${{ matrix.framework-config.framework }}-${{ matrix.framework-config.version }}-php-${{ matrix.php-version }}
-          path: /tmp/report.json
-          if-no-files-found: ignore
+          path: /tmp/reports/
+          retention-days: 30
+          if-no-files-found: warn
 

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -26,8 +26,11 @@ WORKDIR /app
 # Copy composer files
 COPY composer.json composer.lock* ./
 
-# Install dependencies
-RUN composer install --no-interaction --prefer-dist --no-scripts
+# Install dependencies with retry logic and increased timeouts
+RUN composer config --global process-timeout 600 && \
+    composer config --global github-protocols https ssh && \
+    composer install --no-interaction --prefer-dist --no-scripts || \
+    (echo "Retrying with prefer-source..." && composer install --no-interaction --prefer-source --no-scripts)
 
 # Copy application files
 COPY . .

--- a/docs/BRANCH_PROTECTION.md
+++ b/docs/BRANCH_PROTECTION.md
@@ -1,0 +1,130 @@
+# Branch Protection Rules - Konfiguracja
+
+## Problem: Merge przed zakończeniem pipeline
+
+Jeśli zmergowałeś PR zanim pipeline się zakończył, możesz skonfigurować Branch Protection Rules, które wymagają ukończenia wszystkich status checks przed mergem.
+
+## Konfiguracja Branch Protection Rules
+
+### Krok 1: Przejdź do ustawień repozytorium
+
+1. Otwórz repozytorium na GitHub
+2. Kliknij **Settings** → **Branches**
+3. Kliknij **Add rule** lub edytuj istniejącą regułę dla `main`
+
+### Krok 2: Skonfiguruj regułę
+
+**Branch name pattern:** `main` (lub `*` dla wszystkich branchy)
+
+**Zaznacz następujące opcje:**
+
+✅ **Require a pull request before merging**
+   - Require approvals: `1` (lub więcej)
+   - Dismiss stale pull request approvals when new commits are pushed: ✅
+
+✅ **Require status checks to pass before merging**
+   - Require branches to be up to date before merging: ✅
+   - **Status checks that are required:**
+     - `PHP 8.1 on ubuntu-latest`
+     - `PHP 8.2 on ubuntu-latest`
+     - `PHP 8.3 on ubuntu-latest`
+     - `PHP 8.4 on ubuntu-latest`
+     - `Lint`
+     - `Security Scan`
+     - (dodaj wszystkie joby z workflow)
+
+✅ **Require conversation resolution before merging**
+
+✅ **Do not allow bypassing the above settings** (opcjonalne, dla większego bezpieczeństwa)
+
+### Krok 3: Zapisz
+
+Kliknij **Create** lub **Save changes**
+
+## Automatyczne wykrywanie status checks
+
+GitHub automatycznie wykrywa status checks z workflow. Możesz:
+
+1. Utworzyć PR
+2. Poczekać aż workflow się uruchomi
+3. W ustawieniach Branch Protection zobaczysz listę dostępnych status checks
+4. Zaznacz te, które mają być wymagane
+
+## Przykładowa konfiguracja dla tego projektu
+
+Dla `php-compatibility-tester`, wymagane status checks to:
+
+```
+✅ PHP 8.1 on ubuntu-latest
+✅ PHP 8.2 on ubuntu-latest
+✅ PHP 8.3 on ubuntu-latest
+✅ PHP 8.4 on ubuntu-latest
+✅ Lint
+✅ Security Scan
+```
+
+## Workflow z wymaganymi status checks
+
+Aby status checks były widoczne w Branch Protection, muszą być zdefiniowane w workflow:
+
+```yaml
+jobs:
+  tests:
+    name: PHP ${{ matrix.php-version }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    # ... steps ...
+    
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    # ... steps ...
+    
+  security:
+    name: Security Scan
+    runs-on: ubuntu-latest
+    # ... steps ...
+```
+
+## Sprawdzanie status checks w PR
+
+Po skonfigurowaniu Branch Protection Rules:
+
+1. Utwórz nowy PR
+2. Zobaczysz sekcję **"All checks have passed"** lub **"Some checks are still running"**
+3. Przycisk **"Merge pull request"** będzie zablokowany dopóki wszystkie checks nie przejdą
+4. Zobaczysz komunikat: *"Merging is blocked: The base branch requires all commits to be signed"* lub podobny
+
+## Troubleshooting
+
+### Problem: Status checks nie są widoczne
+
+**Rozwiązanie:**
+- Upewnij się, że workflow jest uruchomiony dla PR
+- Sprawdź czy joby mają unikalne nazwy
+- Poczekaj aż workflow się zakończy po raz pierwszy
+
+### Problem: Nie mogę zmergować nawet po przejściu wszystkich checks
+
+**Rozwiązanie:**
+- Sprawdź czy wszystkie wymagane status checks są zaznaczone
+- Upewnij się, że branch jest "up to date" (wymaga rebase/merge z main)
+- Sprawdź czy nie ma innych wymagań (approvals, conversation resolution)
+
+### Problem: Chcę zmergować w trybie awaryjnym
+
+**Rozwiązanie:**
+- Jeśli nie zaznaczyłeś "Do not allow bypassing", możesz użyć "Merge without waiting for requirements to be met" (tylko dla maintainerów)
+- Lub tymczasowo wyłącz Branch Protection Rules
+
+## Best Practices
+
+1. **Zawsze wymagaj status checks** dla głównych branchy (main, master, develop)
+2. **Wymagaj approvals** dla ważnych zmian
+3. **Włącz "Require branches to be up to date"** aby uniknąć konfliktów
+4. **Nie pozwalaj na bypass** w produkcji (chyba że absolutnie konieczne)
+
+## Linki
+
+- [GitHub Docs: About protected branches](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches)
+- [GitHub Docs: Requiring status checks](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#require-status-checks-before-merging)
+


### PR DESCRIPTION
## 🔧 Fix: Ensure Test Reports Are Always Saved as Artifacts

### Problem
Artifacts were not being created in GitHub Actions workflow because:
- Report file might not exist if report generation failed
- `if-no-files-found: ignore` silently skipped artifact creation
- No fallback when report generation fails
- **Artifact names contained invalid characters (`*`) causing upload failures**
- **Docker builds failing due to Composer network timeouts**

### Solution
- ✅ Create reports directory before generating report
- ✅ Save test status even if report generation fails
- ✅ Change `if-no-files-found` from `ignore` to `warn` (so we know when files are missing)
- ✅ Add `retention-days: 30` to artifacts
- ✅ Ensure artifacts directory structure is always created
- ✅ **Fix artifact names by replacing `*` with `x` (e.g., `5.*` → `5.x`)**
- ✅ **Add retry logic and increase timeouts for Composer in Docker builds**

### Changes
- Modified `.github/workflows/self-test.yml`:
  - Create `/tmp/reports/` directory
  - Save fallback JSON if report generation fails
  - Save test status separately
  - Upload entire reports directory instead of single file
  - **Replace `*` in artifact names using `replace()` function**

- Modified `Dockerfile.test`:
  - **Increase Composer process timeout to 600 seconds**
  - **Configure GitHub protocols (https, ssh)**
  - **Add fallback to `--prefer-source` if `--prefer-dist` fails**
  - **Fixes connection timeouts when downloading packages from GitHub**

### Result
Now artifacts will always be created, even if:
- Tests fail
- Report generation fails
- No results are available

Artifacts will contain:
- `report.json` - Generated compatibility test report (or error info)
- `test-status.json` - Test execution status and timestamp

**Artifact names are now valid:**
- `test-results-laravel-11.x-php-8.1` (instead of `11.*`)
- `test-results-symfony-8.0.x-php-8.3` (instead of `8.0.*`)
- `test-results-slim-5.x-php-8.2` (instead of `5.*`)

**Docker builds are more resilient:**
- Increased timeouts prevent premature failures
- Fallback to source installation if dist download fails
- Better handling of network issues

### Related
Fixes issue where artifacts were not visible in GitHub Actions UI.
Fixes 64 errors where artifact names contained invalid `*` character.
Fixes Docker build failures due to network timeouts during composer install.