### PR TITLE
refactor: replace PHPStan with PHPStan Fixer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,9 +54,7 @@ jobs:
       
       - name: Run PHPStan Fixer
         continue-on-error: true
-        run: |
-          composer require --dev phpstan/phpstan --no-interaction || true
-          vendor/bin/phpstan-fixer --phpstan-command="vendor/bin/phpstan analyse src --error-format=json --no-progress" --mode=suggest || true
+        run: vendor/bin/phpstan-fixer --phpstan-command="vendor/bin/phpstan analyse src --error-format=json --no-progress" --mode=suggest || true
       
       - name: Check code style
         continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,9 +52,11 @@ jobs:
       - name: Run PHPUnit tests
         run: vendor/bin/phpunit
       
-      - name: Run PHPStan
+      - name: Run PHPStan Fixer
         continue-on-error: true
-        run: composer require --dev phpstan/phpstan && vendor/bin/phpstan analyse src --level=5 || true
+        run: |
+          composer require --dev phpstan/phpstan --no-interaction || true
+          vendor/bin/phpstan-fixer --phpstan-command="vendor/bin/phpstan analyse src --error-format=json --no-progress" --mode=suggest || true
       
       - name: Check code style
         continue-on-error: true

--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ See [Configuration Documentation](docs/configuration.md) for detailed informatio
 - [Configuration Reference](docs/configuration.md)
 - [Usage Guide](docs/usage.md)
 - [GitHub MCP Server Integration](docs/GITHUB_MCP_INTEGRATION.md) - Automatyczne raportowanie i integracja z GitHub
+- [CI/CD Documentation](docs/ci-cd.md)
 - [Examples](docs/examples/)
 
 ## Links

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,7 @@
     "require-dev": {
         "phpunit/phpunit": "^10.0",
         "lukaszzychal/phpstan-fixer": "^1.0",
-        "vimeo/psalm": "^6.0",
-        "phpstan/phpstan": "^2.1"
+        "vimeo/psalm": "^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,9 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^10.0",
-        "phpstan/phpstan": "^1.10",
-        "vimeo/psalm": "^6.0"
+        "lukaszzychal/phpstan-fixer": "^1.0",
+        "vimeo/psalm": "^6.0",
+        "phpstan/phpstan": "^2.1"
     },
     "autoload": {
         "psr-4": {
@@ -36,4 +37,3 @@
     "minimum-stability": "stable",
     "prefer-stable": true
 }
-

--- a/docs/CI_WORKFLOWS.md
+++ b/docs/CI_WORKFLOWS.md
@@ -10,7 +10,7 @@ This document describes the differences between CI/CD files in the project.
 
 **Checks:**
 - ✅ PHPUnit tests (8.1, 8.2, 8.3, 8.4)
-- ✅ PHPStan (static analysis)
+- ✅ PHPStan Fixer (static analysis with automatic fixes)
 - ✅ PHP-CS-Fixer (code style check)
 - ✅ `composer.json` validation
 - ✅ PHP syntax check
@@ -82,7 +82,7 @@ This document describes the differences between CI/CD files in the project.
 | **Test Type** | Unit + Quality | Docker Isolation | Integration |
 | **Frameworks** | ❌ | ❌ | ✅ (Laravel, Symfony, Slim, CodeIgniter, CakePHP) |
 | **Docker** | ❌ | ✅ | ❌ |
-| **PHPStan** | ✅ | ❌ | ❌ |
+| **PHPStan Fixer** | ✅ | ❌ | ❌ |
 | **Security Scan** | ✅ | ❌ | ❌ |
 | **Execution Time** | ~5-10 min | ~5-10 min | ~20-30 min |
 | **Frequency** | Every push/PR | Every push/PR | Push/PR + monthly |

--- a/docs/CI_WORKFLOWS.pl.md
+++ b/docs/CI_WORKFLOWS.pl.md
@@ -10,7 +10,7 @@ Ten dokument opisuje różnice między plikami CI/CD w projekcie.
 
 **Sprawdza:**
 - ✅ Testy PHPUnit (8.1, 8.2, 8.3, 8.4)
-- ✅ PHPStan (analiza statyczna)
+- ✅ PHPStan Fixer (analiza statyczna z automatycznymi poprawkami)
 - ✅ PHP-CS-Fixer (sprawdzanie stylu kodu)
 - ✅ Walidacja `composer.json`
 - ✅ Sprawdzanie składni PHP
@@ -82,7 +82,7 @@ Ten dokument opisuje różnice między plikami CI/CD w projekcie.
 | **Typ testów** | Jednostkowe + jakość | Izolacja Docker | Integracyjne |
 | **Frameworki** | ❌ | ❌ | ✅ (Laravel, Symfony, Slim, CodeIgniter, CakePHP) |
 | **Docker** | ❌ | ✅ | ❌ |
-| **PHPStan** | ✅ | ❌ | ❌ |
+| **PHPStan Fixer** | ✅ | ❌ | ❌ |
 | **Security Scan** | ✅ | ❌ | ❌ |
 | **Czas wykonania** | ~5-10 min | ~5-10 min | ~20-30 min |
 | **Częstotliwość** | Każdy push/PR | Każdy push/PR | Push/PR + monthly |

--- a/docs/TROUBLESHOOTING_PHPSTAN_FIXER.md
+++ b/docs/TROUBLESHOOTING_PHPSTAN_FIXER.md
@@ -1,0 +1,114 @@
+# ✅ RESOLVED: Binary script fails when package is installed as dependency
+
+## Status: ✅ Fixed in v1.0.3
+
+**Update (2025-12-08):** This issue has been resolved in version **v1.0.3** (commit: `9bb7802dc65c094ea506472f12ad5a62920d5f1e`). The package now uses dynamic autoloader detection, which works correctly both when installed standalone and as a dependency.
+
+## Original Problem Description
+
+The `phpstan-fixer` binary script failed to load the autoloader when the package was installed as a Composer dependency in another project. The script tried to load `vendor/autoload.php` from the package's own directory, which doesn't exist when installed via Composer.
+
+## Original Error Message
+
+```
+Warning: require_once(/path/to/project/vendor/lukaszzychal/phpstan-fixer/bin/../vendor/autoload.php): 
+Failed to open stream: No such file or directory in 
+/path/to/project/vendor/lukaszzychal/phpstan-fixer/bin/phpstan-fixer on line 21
+
+Fatal error: Uncaught Error: Failed opening required 
+'/path/to/project/vendor/lukaszzychal/phpstan-fixer/bin/../vendor/autoload.php' 
+(include_path='.:') in 
+/path/to/project/vendor/lukaszzychal/phpstan-fixer/bin/phpstan-fixer:21
+```
+
+## Solution Implemented
+
+The fix implements the **Alternative Solution** (dynamic autoloader detection) that was proposed in the original issue. The binary script now traverses up the directory tree to find the autoloader, making it work in all installation scenarios:
+
+```php
+// Find the autoloader by traversing up the directory tree
+// This works both when package is standalone and when installed as dependency
+$autoloader = null;
+$dir = __DIR__;
+$maxDepth = 10; // Prevent infinite loops
+
+for ($i = 0; $i < $maxDepth; $i++) {
+    $possiblePath = $dir . '/vendor/autoload.php';
+    if (file_exists($possiblePath)) {
+        $autoloader = $possiblePath;
+        break;
+    }
+    
+    $parentDir = dirname($dir);
+    if ($parentDir === $dir) {
+        // Reached filesystem root
+        break;
+    }
+    $dir = $parentDir;
+}
+
+if ($autoloader === null) {
+    fwrite(STDERR, "Error: Could not find autoload.php.\n");
+    fwrite(STDERR, "Please run 'composer install' to install dependencies.\n");
+    exit(1);
+}
+
+require_once $autoloader;
+```
+
+## Verification
+
+✅ **Tested and confirmed working:**
+- Binary loads correctly when installed as dependency
+- No autoloader errors
+- All functionality works as expected
+- Backward compatible (works in standalone mode too)
+
+## How to Update
+
+If you're experiencing this issue, update to the latest version:
+
+```bash
+composer update lukaszzychal/phpstan-fixer
+```
+
+## Original Issue Details (for reference)
+
+### Steps to Reproduce (Original)
+
+1. Create a new PHP project or use an existing one
+2. Install `phpstan-fixer` as a dev dependency:
+   ```bash
+   composer require --dev lukaszzychal/phpstan-fixer
+   ```
+3. Try to run the binary:
+   ```bash
+   vendor/bin/phpstan-fixer --help
+   ```
+4. The error occurred immediately
+
+### Root Cause (Original)
+
+The binary script at `bin/phpstan-fixer` line 21 used:
+```php
+require_once __DIR__ . '/../vendor/autoload.php';
+```
+
+This assumed the package has its own `vendor` directory, which is only true when:
+- The package is installed standalone (not as a dependency)
+- The package is in development mode with its own dependencies
+
+When installed as a dependency via Composer, the package's dependencies are flattened into the parent project's `vendor` directory, so `vendor/lukaszzychal/phpstan-fixer/vendor/` doesn't exist.
+
+### Environment (Original)
+
+- **Package Version**: v1.0.2 (affected)
+- **Fixed Version**: v1.0.3
+- **PHP Version**: 8.4.7
+- **Composer Version**: 2.8.11
+- **OS**: macOS 25.0.0 (Darwin Kernel, ARM64)
+- **Installation Method**: Composer dependency (`composer require --dev`)
+
+---
+
+**Note:** This file is kept for historical reference. The issue has been resolved and the package works correctly in all installation scenarios.

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -10,7 +10,7 @@ Runs on every push and pull request:
 
 - **Tests**: PHPUnit tests on PHP 8.1, 8.2, 8.3
 - **Linting**: PHP syntax validation and Composer validation
-- **Code Quality**: PHPStan analysis (optional, non-blocking)
+- **Code Quality**: PHPStan Fixer analysis with automatic fix suggestions (optional, non-blocking)
 - **Code Style**: PHP-CS-Fixer checks (optional, non-blocking)
 
 ### Self-Test Workflow (`.github/workflows/self-test.yml`)
@@ -111,6 +111,11 @@ For CI/CD, use GitHub Secrets for sensitive values:
 - Never hardcode secrets in workflow files
 
 ## Troubleshooting
+
+### PHPStan Fixer Issues
+
+If you encounter issues with PHPStan Fixer (autoloader errors, binary not found, etc.), see:
+- [PHPStan Fixer Troubleshooting Guide](TROUBLESHOOTING_PHPSTAN_FIXER.md)
 
 ### CI Fails Due to Secret Detection
 


### PR DESCRIPTION
## 🔄 Refactor: Replace PHPStan with PHPStan Fixer

This PR replaces `phpstan/phpstan` with `lukaszzychal/phpstan-fixer` to enable automatic fixing of PHPStan errors in addition to static analysis.

### Changes

- ✅ **composer.json**: Replace `phpstan/phpstan` with `lukaszzychal/phpstan-fixer`
- ✅ **CI Workflow**: Update to use `phpstan-fixer` with `--no-progress` flag for clean JSON output
- ✅ **Documentation**: Update all references from PHPStan to PHPStan Fixer
- ✅ **Troubleshooting Guide**: Add comprehensive troubleshooting guide for PHPStan Fixer issues
- ✅ **Fix**: Remove redundant `phpstan/phpstan` dependency (already included in `phpstan-fixer`)
- ✅ **Fix**: Simplify CI workflow by removing unnecessary `composer require` step

### Benefits

1. **Automatic Fixes**: PHPStan Fixer can automatically fix many common PHPStan errors
2. **Better Workflow**: Preview changes in `suggest` mode before applying
3. **Framework Agnostic**: Works with any PHP project
4. **Improved CI**: Shows proposed fixes in CI without modifying files
5. **Cleaner Dependencies**: No redundant packages in `composer.json`

### Documentation Updates

- Updated `docs/CI_WORKFLOWS.md` and `docs/CI_WORKFLOWS.pl.md`
- Updated `docs/ci-cd.md` with troubleshooting link
- Added `docs/TROUBLESHOOTING_PHPSTAN_FIXER.md` guide
- Updated `README.md` with CI/CD documentation link

### Testing

- ✅ PHPStan Fixer installed and working
- ✅ Binary script works correctly (issue fixed in v1.0.3)
- ✅ CI workflow updated with proper flags
- ✅ All documentation links verified
- ✅ Redundant dependencies removed
- ✅ Composer install works without errors

### Related

- Issue resolved: PHPStan Fixer autoloader issue fixed in v1.0.3
- See [TROUBLESHOOTING_PHPSTAN_FIXER.md](docs/TROUBLESHOOTING_PHPSTAN_FIXER.md) for details