### PR TITLE
fix: Symfony Console 7.x compatibility (BREAKING CHANGE - v1.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.2] - 2025-12-08
+## [1.1.0] - 2025-12-08
 
 ### Fixed
 
@@ -14,15 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Maintains backward compatibility with Symfony Console 6.x
 - **PHP 8.4 deprecation warnings**: Fixed implicit nullable syntax by using explicit nullable types (`?string`)
   - Applied to `InitCommand::__construct()`, `CompatibilityTester::__construct()`, and `FrameworkTester::__construct()`
-- **Option conflict**: Renamed `--version` to `--framework-version` in `TestCommand`
-  - Prevents conflict with Symfony Console's built-in `--version` option
-  - **Breaking change**: Users must update from `--version` to `--framework-version`
 - **CI workflow**: Added `phpstan/phpstan` as direct dev dependency
   - Ensures PHPStan binary is available in CI workflows
 
 ### Changed
 
-- `TestCommand`: `--version` option renamed to `--framework-version` (breaking change)
+- **BREAKING**: `TestCommand`: `--version` option renamed to `--framework-version`
+  - Prevents conflict with Symfony Console's built-in `--version` option
+  - **Migration**: Update all scripts using `--version` to use `--framework-version` instead
 
 ## [1.0.1] - 2025-12-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - 2025-12-08
+
+### Fixed
+
+- **Symfony Console 7.x compatibility**: Added explicit `setName()` to all commands (InitCommand, TestCommand, ReportCommand)
+  - Required for Symfony Console 7.x compatibility
+  - Maintains backward compatibility with Symfony Console 6.x
+- **PHP 8.4 deprecation warnings**: Fixed implicit nullable syntax by using explicit nullable types (`?string`)
+  - Applied to `InitCommand::__construct()`, `CompatibilityTester::__construct()`, and `FrameworkTester::__construct()`
+- **Option conflict**: Renamed `--version` to `--framework-version` in `TestCommand`
+  - Prevents conflict with Symfony Console's built-in `--version` option
+  - **Breaking change**: Users must update from `--version` to `--framework-version`
+- **CI workflow**: Added `phpstan/phpstan` as direct dev dependency
+  - Ensures PHPStan binary is available in CI workflows
+
+### Changed
+
+- `TestCommand`: `--version` option renamed to `--framework-version` (breaking change)
+
+## [1.0.1] - 2025-12-07
+
+### Changed
+
+- Replaced `phpstan/phpstan` with `lukaszzychal/phpstan-fixer` for automatic PHPStan error fixes
+
 ## [1.0.0] - 2025-01-07
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     "require-dev": {
         "phpunit/phpunit": "^10.0",
         "lukaszzychal/phpstan-fixer": "^1.0",
+        "phpstan/phpstan": "^1.10 || ^2.0",
         "vimeo/psalm": "^6.0"
     },
     "autoload": {

--- a/src/Command/InitCommand.php
+++ b/src/Command/InitCommand.php
@@ -19,7 +19,7 @@ class InitCommand extends Command
 
     private string $packagePath;
 
-    public function __construct(string $packagePath = null)
+    public function __construct(?string $packagePath = null)
     {
         parent::__construct();
         $this->packagePath = $packagePath ?? dirname(__DIR__, 2);
@@ -27,6 +27,7 @@ class InitCommand extends Command
 
     protected function configure(): void
     {
+        $this->setName('init');
         $this->setDescription('Initialize compatibility testing configuration and templates');
     }
 

--- a/src/Command/ReportCommand.php
+++ b/src/Command/ReportCommand.php
@@ -23,6 +23,7 @@ class ReportCommand extends Command
     protected function configure(): void
     {
         $this
+            ->setName('report')
             ->setDescription('Generate compatibility test report')
             ->addOption('format', null, InputOption::VALUE_REQUIRED, 'Report format (markdown, json, html)', 'markdown')
             ->addOption('output', 'o', InputOption::VALUE_REQUIRED, 'Output file path')

--- a/src/Command/TestCommand.php
+++ b/src/Command/TestCommand.php
@@ -24,9 +24,10 @@ class TestCommand extends Command
     protected function configure(): void
     {
         $this
+            ->setName('test')
             ->setDescription('Run compatibility tests')
             ->addOption('framework', 'f', InputOption::VALUE_REQUIRED, 'Filter by framework name')
-            ->addOption('version', null, InputOption::VALUE_REQUIRED, 'Filter by framework version')
+            ->addOption('framework-version', null, InputOption::VALUE_REQUIRED, 'Filter by framework version')
             ->addOption('php', 'p', InputOption::VALUE_REQUIRED, 'Filter by PHP version')
             ->addOption('config', 'c', InputOption::VALUE_REQUIRED, 'Path to configuration file', '.compatibility.yml')
             ->addOption('package-path', null, InputOption::VALUE_REQUIRED, 'Path to the package being tested');
@@ -57,8 +58,8 @@ class TestCommand extends Command
         if ($input->getOption('framework')) {
             $filters['framework'] = $input->getOption('framework');
         }
-        if ($input->getOption('version')) {
-            $filters['version'] = $input->getOption('version');
+        if ($input->getOption('framework-version')) {
+            $filters['version'] = $input->getOption('framework-version');
         }
         if ($input->getOption('php')) {
             $filters['php'] = $input->getOption('php');

--- a/src/CompatibilityTester.php
+++ b/src/CompatibilityTester.php
@@ -18,7 +18,7 @@ class CompatibilityTester
     private array $config = [];
     private string $packagePath;
 
-    public function __construct(string $configPath, string $packagePath = null)
+    public function __construct(string $configPath, ?string $packagePath = null)
     {
         $this->configLoader = new ConfigLoader();
         $this->packagePath = $packagePath ?? getcwd();

--- a/src/FrameworkTester.php
+++ b/src/FrameworkTester.php
@@ -16,7 +16,7 @@ class FrameworkTester
     private string $packagePath;
     private string $tempDir;
 
-    public function __construct(string $packageName, string $packagePath, string $tempDir = null)
+    public function __construct(string $packageName, string $packagePath, ?string $tempDir = null)
     {
         $this->packageName = $packageName;
         $this->packagePath = $packagePath;


### PR DESCRIPTION
## Summary

This PR fixes compatibility issues with Symfony Console 7.x and ensures PHPStan is available in CI workflows. **This is a breaking change release (v1.1.0).**

## ⚠️ Breaking Changes

- **`TestCommand`: `--version` option renamed to `--framework-version`**
  - Prevents conflict with Symfony Console's built-in `--version` option
  - **Migration required**: Update all scripts using `--version` to use `--framework-version` instead
  - Example: `compatibility-tester test --version=11.*` → `compatibility-tester test --framework-version=11.*`

## Changes

### Symfony Console 7.x Compatibility (Fixes #12)

1. **Added explicit `setName()` to all commands**
   - `InitCommand`, `TestCommand`, `ReportCommand`
   - Required for Symfony Console 7.x (commands must explicitly set their name in `configure()`)
   - Maintains backward compatibility with Symfony Console 6.x

2. **Fixed PHP 8.4 deprecation warnings**
   - Changed implicit nullable syntax (`string $param = null`) to explicit (`?string $param = null`)
   - Applied to:
     - `InitCommand::__construct()`
     - `CompatibilityTester::__construct()`
     - `FrameworkTester::__construct()`

3. **Resolved option conflict**
   - Renamed `--version` to `--framework-version` in `TestCommand`
   - Prevents conflict with Symfony Console's built-in `--version` option
   - **Breaking change**: Users must update from `--version` to `--framework-version`

### CI Workflow Fix

4. **Added `phpstan/phpstan` as direct dev dependency**
   - Ensures PHPStan binary is available in CI workflows
   - Previously relied on `phpstan-fixer`'s dev dependency, which may not be installed

## Testing

✅ All commands work correctly:
- `compatibility-tester --help`
- `compatibility-tester list`
- `compatibility-tester init --help`
- `compatibility-tester test --help`
- `compatibility-tester report --help`

✅ No deprecation warnings (PHP 8.4.7)
✅ No option conflicts
✅ PHPStan binary available in CI

## Compatibility

- ⚠️ **Breaking Change**: `--version` → `--framework-version` (requires user action)
- ✅ **PHP Version Support**: Maintains support for PHP 8.1+
- ✅ **Symfony Console**: Compatible with both 6.x and 7.x

## Version

This PR will be released as **v1.1.0** (minor version bump for breaking change, following Semantic Versioning).

## Related Issues

- Fixes #12